### PR TITLE
Clear Line Range Data

### DIFF
--- a/ext-src/rules/rule.ts
+++ b/ext-src/rules/rule.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { v4 as uuidv4 } from 'uuid';
-import { LineRange } from './line-range';
 
 // export class Rule implements Rule {
 //     constructor(id: string) {
@@ -20,8 +19,6 @@ export interface Rule {
     overviewRulerLane: vscode.OverviewRulerLane;
     overviewRulerColor: string;
 
-    occurrences: number | null;
-    lineRanges: LineRange[] | null;
     maxOccurrences: number | null;
     
     regularExpression: string;
@@ -61,8 +58,6 @@ export class Rule implements Rule {
         this.decorationExpanded = false;
         this.overviewRulerColor = '';
         this.overviewRulerLane = vscode.OverviewRulerLane.Full;
-        this.occurrences = 0;
-        this.lineRanges = [];
         this.maxOccurrences = 1000;
         this.regularExpression = '';
         this.regularExpressionFlags = 'g';

--- a/ext-src/rules/ruleFactory.ts
+++ b/ext-src/rules/ruleFactory.ts
@@ -174,10 +174,7 @@ export class RuleFactory {
     }
 
     pushOccurrences(rule: Rule, ranges: LineRange[], occurrences: number) {
-        rule.lineRanges = ranges;
-        rule.occurrences = occurrences;
         this.updateRuleWithNoSideEffects(rule);
-
         this._grepcProvider?.webview?.postMessage({
             type: 'ruleDecorationUpdate',
             id: rule.id,

--- a/webview-ui/grepc-webview/src/services/rule.service.ts
+++ b/webview-ui/grepc-webview/src/services/rule.service.ts
@@ -77,10 +77,31 @@ export class RuleService {
    * Note: This is called by RuleService::pushRules()
    */
   public pushRulesToExtension() {
+    this._clearOccurenceData();
     this.extensionService.postMessage({
       type: 'rules', 
       mapData: JSON.stringify(Array.from(this._ruleMap.entries())),
       arrayData: JSON.stringify(this._rulesArray)
+    });
+  }
+
+  /**
+   * This is to clear occurance data in the rules array and map.
+   * This data does not need to be stored in the backend.
+   * Note: This is called by RuleService::pushRulesToExtension()
+   */
+  private _clearOccurenceData() {
+    this._rulesArray.map(rule =>{ 
+      rule.occurrences = 0;
+      rule.lineRanges = [];
+      return rule;
+    });
+
+    this._ruleMap.forEach(rule => {
+      if(rule) {
+        rule.occurrences = 0;
+        rule.lineRanges = [];
+      }
     });
   }
 

--- a/webview-ui/grepc-webview/src/services/rule.service.ts
+++ b/webview-ui/grepc-webview/src/services/rule.service.ts
@@ -77,7 +77,7 @@ export class RuleService {
    * Note: This is called by RuleService::pushRules()
    */
   public pushRulesToExtension() {
-    this._clearOccurenceData();
+    this._clearOccurrenceData();
     this.extensionService.postMessage({
       type: 'rules', 
       mapData: JSON.stringify(Array.from(this._ruleMap.entries())),
@@ -90,7 +90,7 @@ export class RuleService {
    * This data does not need to be stored in the backend.
    * Note: This is called by RuleService::pushRulesToExtension()
    */
-  private _clearOccurenceData() {
+  private _clearOccurrenceData() {
     this._rulesArray.map(rule =>{ 
       rule.occurrences = 0;
       rule.lineRanges = [];


### PR DESCRIPTION
Closes https://github.com/stneveadomi/grepc/issues/63
The front-end, rule.service.ts, clears out line data and occurrences as that's not needed by the backend. In the back-end, we no longer store line data or occurrences.