### PR TITLE
119 color picker is broken in 130

### DIFF
--- a/webview-ui/grepc-webview/package-lock.json
+++ b/webview-ui/grepc-webview/package-lock.json
@@ -21,7 +21,7 @@
                 "@types/node": "^20.19.1",
                 "@vscode/codicons": "^0.0.35",
                 "html-entities": "^2.6.0",
-                "ngx-color-picker": "^17.0.0",
+                "ngx-color-picker": "^19.0.0",
                 "rimraf": "^5.0.10",
                 "rxjs": "~7.8.0",
                 "tslib": "^2.8.1",
@@ -9859,9 +9859,9 @@
             }
         },
         "node_modules/ngx-color-picker": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/ngx-color-picker/-/ngx-color-picker-17.0.0.tgz",
-            "integrity": "sha512-kHuhW4vErpb0LlBlgTnf1+cYWdaq0gOvDwiX9LeaFKNvhV5li+YEyk7tC3o1Sbhqd4lsFKb8zHyqi1teLWN4Zg==",
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/ngx-color-picker/-/ngx-color-picker-19.0.0.tgz",
+            "integrity": "sha512-jZs7nk/DJB6FryElYnfkojWYCgpEc650s800g+39ebocVMZ18fAHf/CQd5+Bdm4E3zoRod0a0sErJ+c8tGQcCg==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"

--- a/webview-ui/grepc-webview/package.json
+++ b/webview-ui/grepc-webview/package.json
@@ -37,7 +37,7 @@
         "@types/node": "^20.19.1",
         "@vscode/codicons": "^0.0.35",
         "html-entities": "^2.6.0",
-        "ngx-color-picker": "^17.0.0",
+        "ngx-color-picker": "^19.0.0",
         "rimraf": "^5.0.10",
         "rxjs": "~7.8.0",
         "tslib": "^2.8.1",

--- a/webview-ui/grepc-webview/src/app/rule/child-decoration/child-decoration.component.ts
+++ b/webview-ui/grepc-webview/src/app/rule/child-decoration/child-decoration.component.ts
@@ -10,14 +10,14 @@ import {
     ValidationErrors,
     Validator,
 } from '@angular/forms';
-import { ColorPickerModule } from 'ngx-color-picker';
+import { ColorPickerDirective } from 'ngx-color-picker';
 import { Rule, ChildDecorationModel } from '../../../models/rule';
 import { CSSValidator } from '../../../utilities/form-validators';
 import { LoggerService } from '../../../services/logger.service';
 
 @Component({
     selector: 'app-child-decoration',
-    imports: [CommonModule, ReactiveFormsModule, ColorPickerModule],
+    imports: [CommonModule, ReactiveFormsModule, ColorPickerDirective],
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,

--- a/webview-ui/grepc-webview/src/app/rule/rule.component.ts
+++ b/webview-ui/grepc-webview/src/app/rule/rule.component.ts
@@ -19,7 +19,7 @@ import {
 } from '../../models/rule';
 import { CommonModule } from '@angular/common';
 import { SliderCheckboxComponent } from '../slider-checkbox/slider-checkbox.component';
-import { ColorPickerModule } from 'ngx-color-picker';
+import { ColorPickerDirective } from 'ngx-color-picker';
 import { RuleService } from '../../services/rule.service';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Draggable } from '../../utilities/draggable';
@@ -43,10 +43,10 @@ import { ExtensionService } from '../../services/extension.service';
         CommonModule,
         ReactiveFormsModule,
         SliderCheckboxComponent,
-        ColorPickerModule,
         DecorationPreviewComponent,
         OccurrencesComponent,
         ChildDecorationComponent,
+        ColorPickerDirective,
     ],
     templateUrl: './rule.component.html',
     styleUrl: './rule.component.css',

--- a/webview-ui/grepc-webview/src/styles.css
+++ b/webview-ui/grepc-webview/src/styles.css
@@ -93,9 +93,8 @@ app-occurrence {
     display: block;
 }
 
-.color-picker.open {
-    top: 2em !important;
-    left: 0 !important;
+.color-picker {
+    display: block;
 }
 
 .fixed {


### PR DESCRIPTION
Finally addressed this.
Underlying issue was due to the .color-picker being an inline-flex, it was throwing off all the sizing calculations when ngOnInit is run as not all components are loaded then. 

Changing it back to display: block fixes the initial loading. Seems to help with the positioning as well.

Removed some hacky CSS with this as well.